### PR TITLE
Add further mention of boost lib for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,11 @@ set_source_files_properties(${SRC_FILES} PROPERTIES LANGUAGE CXX)
 message(STATUS "Generator : ${CMAKE_GENERATOR}")
 message(STATUS "Build Tool : ${CMAKE_BUILD_TOOL}")
 message(STATUS "Avro install : ${AVRO_INSTALL}")
+message(STATUS "Boost install : ${BOOST_INSTALL}")
 
 include_directories (
 	"${AVRO_INSTALL}/include"
+    "${BOOST_INSTALL}/include"
     ${_VCPKG_ROOT_DIR}/installed/${VCPKG_TARGET_TRIPLET}/include  # where avro-cpp has been installed using vcpkg
     ${CMAKE_BINARY_DIR} # For 'k.h', downloaded below
 )

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ On linux `avrocpp` should be built from source.
 
 #### macOS
 
-On macOS `avrocpp` can be installed using `brew`:
+On macOS `avrocpp` (and its dependancy on `boost`) can be installed using `brew`:
 
 ```bash
-brew install avro-cpp
+brew install avro-cpp boost
 ```
 
 #### Windows
@@ -169,7 +169,8 @@ On Windows `avrocpp` should be built using [vcpkg](https://vcpkg.io/en/):
 In order to successfully build and install this interface from source, the following environment variables must be set:
 
 1. `AVRO_INSTALL` = Location of the Avro C++ API release (only required if `avrocpp` is not installed globally on the system, e.g. on Linux or Windows where `avrocpp` was built from source)
-2. `QHOME` = Q installation directory (directory containing `q.k`)
+2. `BOOST_INSTALL` = Locaion of the Boost C++ library (only required if `boost` is not installed globally on the system)
+3. `QHOME` = Q installation directory (directory containing `q.k`)
 
 From a shell prompt (on Linux/macOS) or Visual Studio command prompt (on Windows), clone the `avrokdb` source from github:
 


### PR DESCRIPTION
Wasnt building on my mac until I installed boost (and also gave it the location when building). Mentioned in readme & added option to point to it via build step.