### PR TITLE
travis stopped supported osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ jobs:
     os: linux
   - dist: xenial
     os: linux    
-  - osx_image: xcode14.2
-    os: osx
   - os: windows
 language: c
 compiler: gcc


### PR DESCRIPTION
travis ci "Starting April 1st, 2025, OSx/macOS builds will no longer be supported due to the end-of-life (EOL) of VMWare support for macOS infrastructure. "